### PR TITLE
Allow for custom HEAD section

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ snap refresh hugo --channel=extended
 
 You can enter your Google / Yandex / etc statistic counter code into the `layouts/partials/counter.html`. Code will be generated right after open `<body>` tag.
 
+## Custom HEAD
+
+If you want to include custom scripts at the end of the `HEAD` section, create a file in `layouts/partials/custom_head.html` and add your content there.
+
 ## Customizing your page
 
 There are different configuration options for Hugo ReFresh including options for: the navbar, the sidebar, the homepage, fonts, colours landing, stats counters and images. 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -20,6 +20,7 @@
     {{- end -}}</title>
 
     {{ partial "css.html" . }}
+    {{ partial "customer_head.html" . }}
   </head>
   <body>
     <!-- Counter -->

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -20,7 +20,7 @@
     {{- end -}}</title>
 
     {{ partial "css.html" . }}
-    {{ partial "customer_head.html" . }}
+    {{ partial "custom_head.html" . }}
   </head>
   <body>
     <!-- Counter -->

--- a/layouts/partials/custom_head.html
+++ b/layouts/partials/custom_head.html
@@ -1,0 +1,1 @@
+<!-- insert your custom head code here -->


### PR DESCRIPTION
I didn't find a clean way to add [plausible-hugo](https://github.com/divinerites/plausible-hugo) to this theme. 
The plausible javascript wants to be loaded in the `<head>` and the theme component didn't work when using the `counter`-partial. Thus, I added a new partial called `custom_head`. 